### PR TITLE
feat: add Slurm job ID to wandb logging

### DIFF
--- a/megatron/neox_arguments/neox_args.py
+++ b/megatron/neox_arguments/neox_args.py
@@ -496,6 +496,11 @@ class NeoXArgsLogging(NeoXArgsTemplate):
     wandb_name: str = None
     """Name of the wandb run."""
 
+    slurm_job_id: str = None
+    """Slurm job ID. If not set and `neox_args.launcher = "slurm"`, the job id will
+    be automatically set from the environment variable, `SLURM_JOB_ID`.
+    """
+
     git_hash: str = get_git_commit_hash()
     """current git hash of repository"""
 

--- a/megatron/utils.py
+++ b/megatron/utils.py
@@ -181,6 +181,9 @@ def init_wandb(neox_args):
                 "Skipping wandb. Execute `wandb login` on local or main node machine to enable.",
                 flush=True,
             )
+        if neox_args.launcher == "slurm" and neox_args.slurm_job_id is None:
+            assert os.environ["SLURM_JOB_ID"] is not None, "SLURM_JOB_ID not set"
+            neox_args.update_value("slurm_job_id", os.environ["SLURM_JOB_ID"])
         wandb.config.update(neox_args.all_config, allow_val_change=True)
 
 


### PR DESCRIPTION
Example run: [W&B Run](https://stability.wandb.io/stability-llm/stable-lm/runs/2r8yr84b) 

cc @reshinthadithyan 