### PR TITLE
Update script to count tokens

### DIFF
--- a/scripts/compute_n_tokens.py
+++ b/scripts/compute_n_tokens.py
@@ -27,39 +27,59 @@ def convert_novelai_to_hf():
     # make sure to load by T5Tokenizer
     # AutoTokenizer calls T5TokenizerFast which is based on unigram. https://huggingface.co/docs/transformers/model_doc/t5#transformers.T5TokenizerFast
     # NovelAI Tokenizer is based on BPE. 
-    tokenizer = T5Tokenizer.from_pretrained("noveai-tokenizer")
-
+    tokenizer = T5Tokenizer.from_pretrained("novelai-tokenizer")
 
 def main():
-    # tokenizer_list = ["abeja/gpt-neox-japanese-2.7b", "rinna/japanese-gpt2-small", "rinna/japanese-gpt-1b", "StabilityAI/stablelm-base-alpha-3b", "naclbit/gpt-j-japanese-6.8b", "cl-tohoku/bert-base-japanese-v2", "novelai"]
-    tokenizer_list = ["novelai"]
-    wiki_files = glob.glob("/fsx/home-mkshing/data/jp_wiki/doc_data/*.txt")
+    model_id = sys.argv[1] # path to model file or name for log
+    mode = sys.argv[2] # mecab, novelai, rinna, or other
+    input_data = sys.argv[3] # en or ja
+    print(f"model_id: {model_id}")
+    print("args:", model_id, mode, input_data)
+    if input_data  == "en":
+        wiki_files = glob.glob("/fsx/home-polm/data/en-data/*2.txt")
+    else:
+        wiki_files = glob.glob("/fsx/home-polm/data/doc_data/*.txt")
     MAX_SAVE_LINES_FOR_UNK = 5000
     OUTPUT_DIR = "logs"
     os.makedirs(OUTPUT_DIR, exist_ok=True)
 
-    for model_id in tqdm(tokenizer_list):
-        print(f"model_id: {model_id}")
-        outfile = os.path.join(OUTPUT_DIR, model_id.replace("/", "-")+".json")
-        if os.path.exists(outfile):
-            continue
-        tokenizer = AutoTokenizer.from_pretrained(model_id) if "novelai" not in model_id else T5Tokenizer.from_pretrained(NOVELAI)
-        summary = {"class": tokenizer.__class__.__name__, "vocab_size": len(tokenizer), "n_tokens": 0, "n_unk": 0, "unk_lines": []}
-        for file in tqdm(wiki_files):
-            with open(file,  "r", encoding="utf-8") as f:
-                for line in f:
-                    line = line.strip()
-                    input_ids = tokenizer.encode(line)
-                    summary['n_tokens'] += len(input_ids)
-                    unk_count = input_ids.count(tokenizer.unk_token_id)
-                    if unk_count > 0:
-                        summary['n_unk'] += unk_count
-                        if len(summary['unk_lines']) <= MAX_SAVE_LINES_FOR_UNK:
-                            summary['unk_lines'].append(line)
-        with open(outfile, "w", encoding="utf-8-sig") as fw:
-            fw.write(json.dumps(summary, indent=4))
-        del tokenizer
+    outfile = os.path.join(OUTPUT_DIR, input_data + model_id.replace("/", "-")+".json")
+    if mode == "mecab":
+        mecab_args = {"mecab_dic": "unidic_lite"}
+        tokenizer = BertJapaneseTokenizer(vocab_file=f"{model_id}.vocab", spm_file=f"{model_id}.model", word_tokenizer_type="mecab", mecab_kwargs=mecab_args, subword_tokenizer_type="sentencepiece")
+    elif mode == "novelai":
+        model_path = "/fsx/home-polm/gpt-neox/scripts/novelai-tokenizer"
+        tokenizer = T5Tokenizer.from_pretrained(model_path)
+    elif mode == "rinna":
+        model_path = "/fsx/home-polm/tokenizer-train/rinna-huggingface"
+        tokenizer = T5Tokenizer.from_pretrained(model_path)
+    else:
+        model_path = model_id
+        tokenizer = T5Tokenizer(
+            model_path,
+            unk_token="<|unknown|>",
+            eos_token="<|endoftext|>",
+            pad_token="<|pad|>",
+            extra_ids=0,
+        )
 
-
-if __name__ == "__main__":
-    main()
+    summary = {"class": tokenizer.__class__.__name__, "vocab_size": len(tokenizer), "n_tokens": 0, "n_unk": 0, "unk_lines": []}
+    for file in tqdm(wiki_files):
+        with open(file,  "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                input_ids = tokenizer.encode(line)
+                if mode == "mecab":
+                    # since this is a bert tokenizer, remove first/last token
+                    input_ids = input_ids[1:-1]
+                else:
+                    # in the T5Tokenizer, an end-of-string marker is added to every input
+                    input_ids = input_ids[:-1]
+                summary['n_tokens'] += len(input_ids)
+                unk_count = input_ids.count(tokenizer.unk_token_id)
+                if unk_count > 0:
+                    summary['n_unk'] += unk_count
+                    if len(summary['unk_lines']) <= MAX_SAVE_LINES_FOR_UNK:
+                        summary['unk_lines'].append(line)
+    with open(outfile, "w", encoding="utf-8-sig") as fw:
+        fw.write(json.dumps(summary, indent=4))


### PR DESCRIPTION
This is pretty messy, but handles a variety of configurations not previously supported and fixes a few issues.

In particular, the T5Tokenizer adds an end of sentence token to every input, so if you just count the IDs, you'll get one extra ID per line, which affects the token count.